### PR TITLE
Fix shot tracking

### DIFF
--- a/battle_royale_sim/agent/agent.py
+++ b/battle_royale_sim/agent/agent.py
@@ -31,9 +31,15 @@ class Agent:
         self.kills          = 0
 
     def tick(self, agents, loot_items):
+        """Update agent state for a single tick.
+
+        Returns the visual representation of a shot if one was fired.
+        """
         # 0) Decide next action
         decision, target = self.behavior.select_action(agents, loot_items)
         self.last_decision = decision
+
+        shot = None
 
         # 1) Execute: either attack or move, and record what actually happened
         if decision == 'attack':
@@ -56,6 +62,8 @@ class Agent:
             dmg = self.storm.damage()
             self.health -= dmg
             log_event('storm_damage', {'agent': self.id, 'damage': dmg})
+
+        return shot
 
 
     def attack(self, agents):

--- a/battle_royale_sim/engine.py
+++ b/battle_royale_sim/engine.py
@@ -175,21 +175,16 @@ class GameEngine:
             self.loot_items.extend(inside)
 
         # 3) Agent actions: decide, move/attack, pickup, storm damage & elimination
+        self.shots = []
         for a in self.agents[:]:
-            # tick now accepts both agents list and loot_items
-            a.tick(self.agents, self.loot_items)
+            shot = a.tick(self.agents, self.loot_items)
+            if shot:
+                self.shots.append(shot)
             if a.health <= 0:
                 log_event('eliminate', {'agent': a.id})
                 self.agents.remove(a)
 
-        # 4) Combat: collect shot visuals
-        self.shots = []
-        for a in self.agents:
-            shot = a.attack(self.agents)
-            if shot:
-                self.shots.append(shot)
-
-        # 5) Post-combat elimination (in case attack killed someone)
+        # 4) Post-combat elimination (in case attack killed someone)
         for a in self.agents[:]:
             if a.health <= 0:
                 log_event('eliminate', {'agent': a.id})


### PR DESCRIPTION
## Summary
- fix engine update so attack shots are collected once per tick
- return shot info from `Agent.tick`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c30c4f9348322ab1474718ec63678