### PR TITLE
Fix random blue channel range

### DIFF
--- a/make_floor.py
+++ b/make_floor.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 width, height = 32, 32
 red = np.random.randint(110, 140, (height, width))
 green = np.random.randint(120, 130, (height, width))
-blue = np.random.randint(110, 1355, (height, width))
+blue = np.random.randint(110, 135, (height, width))
 
 # Stack into RGB image
 grass = np.stack((red, green, blue), axis=2).astype(np.uint8)


### PR DESCRIPTION
## Summary
- limit blue channel range in `make_floor.py` to keep RGB values within 0-255

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c34fb86dc832297d4c72586d7cd38